### PR TITLE
Add Script wrapper to allow enter/exit handling ;)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With this comes a variety of somewhat neccessary functionalities that lodepy imp
 # Using lodepy
 In it's current state the main interaction is going to be with the [Group](https://github.com/tkatchen/lodepy/blob/main/src/lodepy/groups/group.py) class and its subclasses (namely the [GroupReturn](https://github.com/tkatchen/lodepy/blob/main/src/lodepy/groups/group_return.py)).
 
-1) Definining a group is quickly done with the use of `lodepy.import_group_txt(file: str) -> Dict[str, Group]`
+1) Definining a group is quickly done with the use of `Main.import_group_txt(file: str) -> Dict[str, Group]`
    1) This is going to be in the format of:
       ```
       [group1]
@@ -28,7 +28,7 @@ In it's current state the main interaction is going to be with the [Group](https
       [group_name]
       node_name, ssh_ip
       ```
-   2) Note, already created groups can be found in the `lodepy.data_store().groups`
+   2) Note, already created groups can be found in the `Main.get_groups()`
 
 2) Executing commands
    1) We can then execute a variety of Group commands. A series of these are listed as functions of Group.py.
@@ -52,3 +52,21 @@ In it's current state the main interaction is going to be with the [Group](https
 
 
 In total this is the entire functionality loop of lodepy. There is still more to cover (and to implement), but to expect: log handling / streaming results elsewhere, more configurability (error handling, execution tuning, etc.), a variety of builtin Tasks for common usecases and the ability to seamlessly create more Tasks (and recursively handle encapsuled tasks).
+
+# Example
+
+```python
+with Script() as s:
+    # Get new groups
+    groups = s.import_group_txt('groups.txt')
+    # or if we've imported before:
+    groups = s.get_groups()
+
+    # Get a specific group and execute a task
+    group1 = groups['group1']
+    res = group1.execute_task(GitVersion())
+
+    # Filter result and update old versions
+    old_versions = res < '1.0.0'
+    old_versions.execute_task(APTGet('git', version='1.0.0'))
+```

--- a/src/lodepy/core/__init__.py
+++ b/src/lodepy/core/__init__.py
@@ -1,4 +1,5 @@
 'core module imports'
-from .main import Main, init, data_store, import_groups_txt
+from .main import Main
 from .comparable import Comparable
 from .operable import Operable
+from .script import Script

--- a/src/lodepy/core/main.py
+++ b/src/lodepy/core/main.py
@@ -8,89 +8,72 @@ from lodepy.nodes.node import Node
 
 class Main():
     '''
-    The static accessor to all of lodepy
+    The main accessor to all of lodepy
     '''
-    data_store: DataStore = None
-
-    @classmethod
-    def init(cls, data_dir: str, file_name: str):
+    def __init__(self, file_name: str):
         '''
-        Initialize the static lodepy instance
+        Initialize the lodepy instance
+
+        :file_name: The name of the file to pull the data store from.
         '''
-        cls.data_store = DataStore(data_dir, file_name)
+        self.data_store: DataStore = DataStore(file_name)
 
 
-def init(data_dir: str, file_name: str) -> None:
-    '''
-    Initialize the lodepy instance
+    def get_groups(self) -> Dict[str, Group]:
+        '''
+        Get the Groups from disk.
 
-    :data_dir: The directory to pull the saved data store from.
-    :file_name: The name of the file to pull the data store from.
-    '''
-    Main.init(data_dir, file_name)
+        The file is stored in /etc/lodepy/nodes.txt
+        Should be the same format as the input for import_groups_txt
 
-
-def data_store() -> DataStore:
-    '''
-    Access the lodepy data store
-
-    :return: The static data store for the lodepy instance
-    '''
-    return Main.data_store
+        :return: A dictionary from the groups name to the relative group
+        '''
+        return self.import_groups_txt('/etc/lodepy/nodes.txt')
 
 
-def get_groups() -> Dict[str, Group]:
-    '''
-    Get the Groups from disk.
+    def import_groups_txt(self, file_name: str) -> Dict[str, Group]:
+        '''
+        Import a series of groups from a formatted text file
 
-    The file is stored in /etc/lodepy/nodes.txt
-    Should be the same format as the input for import_groups_txt
+        :file_name: The name of the file to pull data from
 
-    :return: A dictionary from the groups name to the relative group
-    '''
-    return import_groups_txt('/etc/lodepy/nodes.txt')
+        :return: A dictionary from the groups name to the relative group
+        '''
 
+        res = {}
 
-def import_groups_txt(file_name: str) -> Dict[str, Group]:
-    '''
-    Import a series of groups from a formatted text file
+        cur_group: Group = None
 
-    :file_name: The name of the file to pull data from
+        with open(file_name) as file:
+            lines = [x[:-1] for x in file.readlines()]
+            for cur in lines:
+                # Empty line
+                if len(cur) == 0:
+                    continue
 
-    :return: A dictionary from the groups name to the relative group
-    '''
+                # Find new Group
+                if cur.startswith('[') and cur.endswith(']'):
+                    if cur_group != None:
+                        res[cur_group.name] = cur_group
 
-    res = {}
+                    group_name = cur[1:-1]
+                    cur_group = Group(group_name, set())
 
-    cur_group: Group = None
+                # Node found
+                if cur_group == None:
+                    continue
 
-    with open(file_name) as file:
-        lines = [x[:-1] for x in file.readlines()]
-        for cur in lines:
-            # Empty line
-            if len(cur) == 0:
-                continue
+                info = cur.split(',')
+                if len(info) != 2:
+                    continue
 
-            # Find new Group
-            if cur.startswith('[') and cur.endswith(']'):
-                if cur_group != None:
-                    res[cur_group.name] = cur_group
+                new_node = Node(info[0].strip(), info[1].strip())
+                cur_group.add_node(new_node)
 
-                group_name = cur[1:-1]
-                cur_group = Group(group_name, set())
+        if cur_group != None:
+            res[cur_group.name] = cur_group
 
-            # Node found
-            if cur_group == None:
-                continue
+        for group_name, group in res.values():
+            self.data_store.groups[group_name] = group
 
-            info = cur.split(',')
-            if len(info) != 2:
-                continue
-
-            new_node = Node(info[0].strip(), info[1].strip())
-            cur_group.add_node(new_node)
-
-    if cur_group != None:
-        res[cur_group.name] = cur_group
-
-    return res
+        return res

--- a/src/lodepy/core/script.py
+++ b/src/lodepy/core/script.py
@@ -1,0 +1,17 @@
+from lodepy.core.main import Main
+
+
+class Script():
+    def __init__(self,
+                 store_file: str = None,
+                ):
+        '''
+        :store_file: The file that is going to store all of the runs variables
+        '''
+        self.main = Main(store_file)
+
+    def __enter__(self) -> Main:
+        return self.main
+        
+    def __exit__(self) -> None:
+        self.main.data_store.write_data()

--- a/src/lodepy/data/data_store.py
+++ b/src/lodepy/data/data_store.py
@@ -17,12 +17,10 @@ class DataStore():
 
     Functionally, this is a dictionary with information that can be utilized by any host.
 
-    :data_dir: The directory to store the data
     :file_name: The name of the file to store in
     '''
 
-    def __init__(self, data_dir: str, file_name='.') -> None:
-        self.data_dir = data_dir
+    def __init__(self, file_name='/etc/lodepy/datastore.txt') -> None:
         self.file_name = file_name
         data, nodes, groups = self._load_data()
         self.data: Dict[str, any] = {} if data is None else data

--- a/src/lodepy/groups/group_return.py
+++ b/src/lodepy/groups/group_return.py
@@ -125,3 +125,16 @@ class GroupReturn(Group, Comparable['GroupReturn[K]'], Operable['GroupReturn[K]'
                 res[node_ret.name] = node_ret
 
         return GroupReturn(res)
+    
+    def update_node_variables(self, key: str) -> None:
+        '''
+        Update the Node's NodeVariables with it's corresponding return value.
+
+        :param key:
+            The key to set for this node variable
+        '''
+
+        for node_ret in self.values.values():
+            node_ret.information.set(
+                key, node_ret.value
+            )

--- a/src/lodepy/tasks/task.py
+++ b/src/lodepy/tasks/task.py
@@ -14,7 +14,7 @@ class Task(Generic[K]):
     '''
 
     def __init__(self, **kwargs) -> None:
-        self.ssh = True
+        self.ssh : bool = True
         if 'ssh' in kwargs:
             self.ssh = kwargs['ssh']
 


### PR DESCRIPTION
Wowza. So I had a think recently:

We need to handle users entering and exiting a lodepy "Script" (for example, we need to know when to read/write to DataStore file, when to log, etc.). So, I've made is such that now scripts are to be wrapped inside a `with` statement (similar to `open(file)`). Now we can add whatever enter/exit manegement to the `Script.py` file and access (the "as") is simply a `Main` instance.